### PR TITLE
Revamp documentation site with new landing page and contribution flow

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,9 @@
+---
+layout: default
+title: Overview
+nav_order: 2
+---
+
 <html>
     <!-- We cannot use CSS anywhere in this page, because the GitHub main repo doesn't render it. CSS is fine within the other docs pages though. -->
     <div align="center">

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -1,4 +1,5 @@
 title: Venice
+logo: /assets/style/venice_full_lion_logo.svg
 remote_theme: just-the-docs/just-the-docs
 favicon_ico: "/assets/style/favicon.ico"
 

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -6,3 +6,32 @@
     font-weight: bold;
   }
 }
+.home-hero {
+  text-align: center;
+  margin: 2rem auto;
+}
+.home-hero .hero-logo {
+  max-width: 300px;
+  width: 40%;
+}
+.home-hero .hero-buttons .btn {
+  margin: 0.2rem;
+}
+.home-sections {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: 1rem;
+  margin-top: 2rem;
+}
+.home-sections .card {
+  border: 1px solid #444;
+  border-radius: 0.5rem;
+  padding: 1rem;
+  width: 18rem;
+  text-align: center;
+}
+.home-sections .card .btn {
+  margin-top: 0.5rem;
+}
+

--- a/docs/contribute.md
+++ b/docs/contribute.md
@@ -1,0 +1,16 @@
+---
+layout: default
+title: Contribute
+nav_order: 6
+---
+
+# Contribute
+
+Start with the [How to Contribute to Venice](dev_guide/how_to/how_to.md) guide for setting up your environment and submitting changes.
+
+Join the community:
+
+- [Slack workspace](http://slack.venicedb.org) (archived on [Linen](http://linen.venicedb.org))
+- [LinkedIn group](https://www.linkedin.com/groups/14129519/)
+- [GitHub issues](https://github.com/linkedin/venice/issues)
+

--- a/docs/dev_guide/dev_guide.md
+++ b/docs/dev_guide/dev_guide.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Developer Guides
+nav_order: 4
 has_children: true
 permalink: /docs/dev_guide
 ---

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,44 @@
+---
+layout: default
+title: Venice
+nav_order: 1
+---
+
+<div class="home-hero">
+  <img src="assets/style/venice_full_lion_logo.svg" alt="Venice logo" class="hero-logo" />
+  <h1 class="hero-title">Venice</h1>
+  <p class="hero-tagline">Derived Data Platform for Planet-Scale Workloads</p>
+  <div class="hero-buttons">
+    <a href="quickstart/quickstart" class="btn btn-primary">Quickstart</a>
+    <a href="dev_guide/dev_guide" class="btn">Developer Docs</a>
+    <a href="dev_guide/how_to/how_to" class="btn">Contribute</a>
+  </div>
+</div>
+
+Venice is a derived data storage platform, providing the following characteristics:
+
+1. High throughput asynchronous ingestion from batch and streaming sources (e.g. [Hadoop](https://github.com/apache/hadoop) and [Samza](https://github.com/apache/samza)).
+2. Low latency online reads via remote queries or in-process caching.
+3. Active-active replication between regions with CRDT-based conflict resolution.
+4. Multi-cluster support within each region with operator-driven cluster assignment.
+5. Multi-tenancy, horizontal scalability and elasticity within each cluster.
+
+<div class="home-sections">
+  <div class="card">
+    <h2>Get Started</h2>
+    <p>Spin up a Venice cluster and try features like creating a data store, batch push, incremental push, and single get.</p>
+    <a href="quickstart/quickstart" class="btn btn-primary">Quickstart Guides</a>
+  </div>
+  <div class="card">
+    <h2>Maintain</h2>
+    <p>Learn about project internals and operations.</p>
+    <a href="dev_guide/dev_guide" class="btn">Developer Guide</a>
+    <a href="ops_guide/ops_guide" class="btn">Operator Guide</a>
+  </div>
+  <div class="card">
+    <h2>Contribute</h2>
+    <p>Join the community and help improve Venice.</p>
+    <a href="dev_guide/how_to/how_to" class="btn">Contributor Guide</a>
+  </div>
+</div>
+

--- a/docs/ops_guide/ops_guide.md
+++ b/docs/ops_guide/ops_guide.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Operator Guides
+nav_order: 5
 has_children: true
 permalink: /docs/ops_guide
 ---

--- a/docs/quickstart/quickstart.md
+++ b/docs/quickstart/quickstart.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Quickstart
+nav_order: 3
 has_children: true
 permalink: /docs/quickstart
 ---


### PR DESCRIPTION
## Summary
- Add new docs landing page with logo, feature overview, and quick links to key guides
- Introduce dedicated contribute page and update navigation order
- Style homepage sections and show project logo in site config

## Testing
- `bundle install`
- `PAGES_REPO_NWO=linkedin/venice bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_68b65440b9c4832b8a374d89f75f0c75